### PR TITLE
Add a new endpoing /sqldump, exporting the data for the current modules.

### DIFF
--- a/main.v
+++ b/main.v
@@ -6,6 +6,7 @@ import (
 	json
 	rand
 	time
+	os
 )
 
 const (
@@ -53,6 +54,11 @@ pub fn (app mut App) new() {
 	logged_in := app.cur_user.name != '' 
 	println('new() loggedin: $logged_in') 
 	println(123) // TODO remove, won't work without it 
+	$vweb.html()
+}
+
+pub fn (app mut App) sqldump() {
+	sql := os.exec('pg_dump vpm --table=modules --no-password --username=admin') or { return }
 	$vweb.html()
 }
 

--- a/sqldump.html
+++ b/sqldump.html
@@ -1,0 +1,2 @@
+--- sql.exit_code: @sql.exit_code
+@sql.output


### PR DESCRIPTION
This enables easier onboarding of contributors (they can test their
changes locally using real data).