### PR TITLE
fix: packages starts count

### DIFF
--- a/lib/github/api.v
+++ b/lib/github/api.v
@@ -16,6 +16,20 @@ pub fn get_repo_by_id(id int) !Repository {
 	return json2.decode[Repository](res.body)
 }
 
+pub fn get_repo_by_username_and_name(username string, name string) !Repository {
+	res := http.fetch(
+		method: .get
+		url: github.api + '/repos/${username}/${name}'
+		user_agent: 'vpm'
+	)!
+
+	if res.status() != .ok {
+		return error('status not ok: ${res.status()}, ${res.body}')
+	}
+
+	return json2.decode[Repository](res.body)
+}
+
 pub struct Client {
 	authorization string
 }

--- a/lib/github/repos.v
+++ b/lib/github/repos.v
@@ -32,101 +32,103 @@ pub fn (mut p Permissions) from_json(obj json2.Any) {
 	ju.to(mut p, obj.as_map())
 }
 
+// TODO: one or a few fields here are wrong, and when deserializing correct GitHub API response, it panics with error "V panic: array index out of range".
+// Investigation and fix needed
 [heap]
 pub struct Repository {
 pub mut:
-	id             i64
-	node_id        string
-	name           string
-	full_name      string
-	license        License
-	organization   User
-	permissions    Permissions
-	owner          User
-	description    string      [omitempty]
-	topics         []string
-	default_branch string
-	master_branch  string
-	homepage       string      [omitempty]
-	language       string      [omitempty]
-	size           int
-	// Can be `public`, `private` or `internal`.
-	visibility string
-	private    bool
-	fork       bool
-	archived   bool
-	disabled   bool
-
-	open_issues_count int
-	forks_count       int
-	stargazers_count  int
-	subscribers_count int
-	network_count     int
-
-	has_issues    bool
-	has_projects  bool
-	has_wiki      bool
-	has_pages     bool
-	has_downloads bool
-
-	allow_rebase_merge     bool
-	allow_squash_merge     bool
-	allow_merge_commit     bool
-	allow_auto_merge       bool
-	delete_branch_on_merge bool
-
-	is_template bool
-	// template_repository &Repository
-	temp_clone_token string [omitempty]
-
-	starred_at time.Time
-	pushed_at  time.Time
-	created_at time.Time
-	updated_at time.Time
-
-	url               string
-	html_url          string
-	archive_url       string
-	assignees_url     string
-	blobs_url         string
-	branches_url      string
-	collaborators_url string
-	comments_url      string
-	commits_url       string
-	compare_url       string
-	contents_url      string
-	contributors_url  string
-	deployments_url   string
-	downloads_url     string
-	events_url        string
-	forks_url         string
-	git_commits_url   string
-	git_refs_url      string
-	git_tags_url      string
-	git_url           string
-	issue_comment_url string
-	issue_events_url  string
-	issues_url        string
-	keys_url          string
-	labels_url        string
-	languages_url     string
-	merges_url        string
-	milestones_url    string
-	notifications_url string
-	pulls_url         string
-	releases_url      string
-	ssh_url           string
-	stargazers_url    string
-	statuses_url      string
-	subscribers_url   string
-	subscriptions_url string
-	tags_url          string
-	teams_url         string
-	trees_url         string
-	clone_url         string
-	mirror_url        string [omitempty]
-	hooks_url         string
-	svn_url           string
+	// id             i64
+	// node_id        string
+	// name           string
+	// full_name      string
+	license      License
+	organization User
+	permissions  Permissions
+	owner        User
+	// description    string      [omitempty]
+	// topics         []string
+	// default_branch string
+	// master_branch  string
+	// homepage       string      [omitempty]
+	// language       string      [omitempty]
+	// size           int
+	// // Can be `public`, `private` or `internal`.
+	// visibility string
+	// private    bool
+	// fork       bool
+	// archived   bool
+	// disabled   bool
+	//
+	// open_issues_count int
+	// forks_count       int
+	stargazers_count int
+	// subscribers_count int
+	// network_count     int
+	//
+	// has_issues    bool
+	// has_projects  bool
+	// has_wiki      bool
+	// has_pages     bool
+	// has_downloads bool
+	//
+	// allow_rebase_merge     bool
+	// allow_squash_merge     bool
+	// allow_merge_commit     bool
+	// allow_auto_merge       bool
+	// delete_branch_on_merge bool
+	//
+	// is_template bool
+	// // template_repository &Repository
+	// temp_clone_token string [omitempty]
+	//
+	// starred_at time.Time
+	// pushed_at  time.Time
+	// created_at time.Time
+	// updated_at time.Time
+	//
+	// url               string
+	// html_url          string
+	// archive_url       string
+	// assignees_url     string
+	// blobs_url         string
+	// branches_url      string
+	// collaborators_url string
+	// comments_url      string
+	// commits_url       string
+	// compare_url       string
+	// contents_url      string
+	// contributors_url  string
+	// deployments_url   string
+	// downloads_url     string
+	// events_url        string
+	// forks_url         string
+	// git_commits_url   string
+	// git_refs_url      string
+	// git_tags_url      string
+	// git_url           string
+	// issue_comment_url string
+	// issue_events_url  string
+	// issues_url        string
+	// keys_url          string
+	// labels_url        string
+	// languages_url     string
+	// merges_url        string
+	// milestones_url    string
+	// notifications_url string
+	// pulls_url         string
+	// releases_url      string
+	// ssh_url           string
+	// stargazers_url    string
+	// statuses_url      string
+	// subscribers_url   string
+	// subscriptions_url string
+	// tags_url          string
+	// teams_url         string
+	// trees_url         string
+	// clone_url         string
+	// mirror_url        string [omitempty]
+	// hooks_url         string
+	// svn_url           string
 }
 
 pub fn (mut r Repository) from_json(obj json2.Any) {


### PR DESCRIPTION
Fixes #47

# This PR implements 2 things for now: 

- allow the admin (test_user) to submit packages for GitHub repos they doesn't manage.
- adding stars count to the newly added package.

# Problem

The problem is not trivial, however.

Currently, 3 problems with starts need to be addressed:

1. Stars count for newly added packages
2. Stars count for already existing packages
3. Handling stars count change in realtime

# Solution

One way to resolve the issue - on start, VPM can iterate over all packages currently in DB and do 2 things:

1. Fetch the current stars count from GitHub and update data in DB
2. Subscribe on event/webhook for stars count update

This will add some time to the VPM start time (probably if we split requests on different processes it will go faster).

Also, when the user adds a new package to VPM, it needs to subscribe on event/webhook for the stars count update for this repo as well.

In this way, we will have a good user experience, up-to-date starts count data (without migration for old packages required), and will no exceed the GitHub API rate limit.