### PR TITLE
Add `dev_user` config option

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 root_url = "https://vpm.vlang.io"
 is_dev = true
+dev_user = "test_user"
 
 [jwt]
 secret = "some_very_secure_secret"
@@ -13,7 +14,7 @@ port = 8081
 
 [postgres]
 host = "localhost"
-port = 5433
+port = 5432
 user = "vpm"
 password = "vpm"
 db = "vpm"

--- a/config/config.v
+++ b/config/config.v
@@ -11,6 +11,7 @@ pub mut:
 	http     HTTP
 	pg       Postgres
 	is_dev   bool
+	dev_user string
 }
 
 pub struct JWT {
@@ -71,6 +72,7 @@ pub fn parse(data string) !Config {
 			db: cfg.value('postgres.db').default_to('vpm').string()
 		}
 		is_dev: cfg.value('is_dev').default_to('false').bool()
+		dev_user: cfg.value('dev_user').default_to('test_user').string()
 	}
 }
 

--- a/main.v
+++ b/main.v
@@ -68,7 +68,7 @@ fn main() {
 
 	if conf.is_dev {
 		app.cur_user = User{
-			username: 'test_user'
+			username: conf.dev_user
 			is_admin: true
 		}
 	}


### PR DESCRIPTION
### What:
- Add a config option to change the `test_user` user that is currently used in development mode.
- Changes default port for postgres to 5432. According to [this](https://www.cisco.com/c/en/us/td/docs/voice_ip_comm/cucm/im_presence/database_setup/10_5_2/CUP0_BK_D4BFFAC9_00_database-setup-guide-imp-1052/CUP0_BK_D4BFFAC9_00_database-setup-guide-imp-1052_chapter_01.pdf) its the default port for postgres, _not_ 5433

### Why:
- It makes it possible / easier to set your own GitHub username and add packages locally:

![image](https://github.com/vlang/vpm/assets/32339757/baba0b21-99c8-4afa-bfbf-0efccb886bd6)
