### PR TITLE
87-add-package-installation-instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Instantly publish your modules and install them. Use the API to interact and fin
 To run it locally, just run
 
 ```bash
+v install
 v .
 ```
 


### PR DESCRIPTION
This pull request adds a preleminary instruction to `v .` in order to install packages. Without this command, the package `markdown` cannot be found.