### PR TITLE
fix: skip `author` field in Package entity

### DIFF
--- a/src/entity/package.v
+++ b/src/entity/package.v
@@ -13,7 +13,8 @@ pub mut:
 	nr_downloads  int
 	vcs           string = 'git'
 	user_id       int
-	author        User      @[fkey: 'id']
+	author_id     int       @[json: '-']
+	author        User      @[sql: '-']
 	stars         int
 	is_flatten    bool // No need to mention author of package, example `ui`
 	updated_at    time.Time = time.now()


### PR DESCRIPTION
Closes #126

- Modified the `Package` struct to skip the `author` field to resolve an issue where a User was being automatically created when creating a Package
- Added an `author_id` field to ensure the `author_id` column is still created in the Package table (for backward compatibility)
- After looking through the source code, I couldn't find where `author_id` is actively used, so this change should not affect existing behavior
  - When getting for a package's author, the `user_id` is used instead (not `author_id`)
    - https://github.com/koki-develop/vpm/blob/d81991115af5367cdd8443e09c679efdff04f654/src/usecase/package/packages.v#L98

To be honest, I'm not that familiar with vlang so I'm not sure if this approach is correct, but it solved the problem at least locally.