### PR TITLE
add support for readme files not named README.md

### DIFF
--- a/src/auth.v
+++ b/src/auth.v
@@ -78,7 +78,7 @@ fn (mut app App) oauth_cb() vweb.Result {
 	return app.redirect('/new')
 }
 
-@[markused]
+// @[markused]
 fn (mut app App) auth() {
 	id_cookie := app.get_cookie('id') or { return }
 	id := id_cookie.int()

--- a/src/usecase/package/readme.v
+++ b/src/usecase/package/readme.v
@@ -7,20 +7,20 @@ import x.json2
 // https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes
 // each possible path a readme can be read from, in descending order of priority
 const readme_paths = [
-	'/.github/'
-	'/'
-	'/docs/'
+	'/.github/',
+	'/',
+	'/docs/',
 ]
 
 // common readme file cases
-const readme_cases = [ 'README', 'readme' ]
+const readme_cases = ['README', 'readme']
 
 // vpm can only render markdown and plaintext, but github supports a large amount of formats:
 // https://stackoverflow.com/a/41112364
 const readme_exts = [
-	'md'
-	'txt'
-	'' // readmes with no file extension are plaintext by default
+	'md',
+	'txt',
+	'', // readmes with no file extension are plaintext by default
 ]
 
 const valid_readme_paths = get_possible_readme_paths()

--- a/src/usecase/package/readme.v
+++ b/src/usecase/package/readme.v
@@ -4,6 +4,39 @@ import net.http
 import net.urllib
 import x.json2
 
+// https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes
+// each possible path a readme can be read from, in descending order of priority
+const readme_paths = [
+	'/.github/'
+	'/'
+	'/docs/'
+]
+
+// common readme file cases
+const readme_cases = [ 'README', 'readme' ]
+
+// vpm can only render markdown and plaintext, but github supports a large amount of formats:
+// https://stackoverflow.com/a/41112364
+const readme_exts = [
+	'md'
+	'txt'
+	'' // readmes with no file extension are plaintext by default
+]
+
+const valid_readme_paths = get_possible_readme_paths()
+
+fn get_possible_readme_paths() []string {
+	mut paths := []string{}
+	for path in readme_paths {
+		for case in readme_cases {
+			for ext in readme_exts {
+				paths << '${path}/${case}.${ext}'
+			}
+		}
+	}
+	return paths
+}
+
 pub fn (u UseCase) get_package_markdown(name string) !string {
 	pkg := u.packages.get(name)!
 
@@ -19,15 +52,14 @@ pub fn (u UseCase) get_package_markdown(name string) !string {
 	branch := body.as_map()['default_branch'] or { json2.Any('main') }
 
 	// Getting raw readme markdown
-	aa := 'https://raw.githubusercontent.com${url.path}/${branch}/README.md'
-	readme := http.get(aa)!
-	if readme.status() != http.Status.ok {
-		return error('readme status is not 200, real ${api_repo.status()}')
+	for path in valid_readme_paths {
+		readme_url := 'https://raw.githubusercontent.com${url.path}/${branch}/${path}'
+		readme := http.get(readme_url)!
+		if readme.status() == http.Status.ok {
+			return readme.body
+		}
 	}
 
-	return readme.body
-}
-
-fn format_raw_content_url(user string, repo string, branch string, file string) string {
-	return 'https://raw.githubusercontent.com/${user}/${repo}/${branch}/${file}'
+	// If no readme is found, just return blank
+	return ''
 }


### PR DESCRIPTION
This PR allows VPM to fetch readme files that are not named README.md at the root of a repo.

It allows support for readmes in `.github`, `/`, `/doc/` (prioritized in that order), they can be cased as `README` or `readme`, and with the extension `.md`, `.txt`, or none (plain text)

Also commented out @[markused] on auth.v#auth, this seems to be causing an error.