### PR TITLE
fix db.close() for new interface

### DIFF
--- a/src/main.v
+++ b/src/main.v
@@ -25,7 +25,7 @@ fn main() {
 	})!
 
 	defer {
-		db.close()
+		db.close() or {}
 	}
 
 	repo.migrate(db)!


### PR DESCRIPTION
As PR (vlang/v#24780) modify the db `close()` to using the pool interface.
