### PR TITLE
make queries case insensitive

### DIFF
--- a/src/repo/package.v
+++ b/src/repo/package.v
@@ -47,7 +47,7 @@ pub fn (p PackagesRepo) get_by_id(id int) !Package {
 fn (p PackagesRepo) find_by_query(query string) []Package {
 	q := '%' + query + '%'
 	pkgs := sql p.db {
-		select from Package where name like q
+		select from Package where name ilike q || description ilike q
 	} or { [] }
 
 	return pkgs


### PR DESCRIPTION
Closes #123 

Also allows searching in descriptions which the current search doesn't. If this isn't wanted I can revert that portion.